### PR TITLE
Remove beta channel

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -17,8 +17,6 @@ def run_command(command)
     end
 end
 
-run_command("flutter channel beta")
-run_command("flutter upgrade")
 run_command("flutter config --enable-web")
 run_command("cd #{ac_flutter_project_dir} && flutter build web")
 


### PR DESCRIPTION
This commit removes the beta channel from the install step. The user expects to use the same version they set at `Flutter Install` step